### PR TITLE
fix broken link to getRegion documentation

### DIFF
--- a/docs/demos/node.md
+++ b/docs/demos/node.md
@@ -27,4 +27,4 @@ const ewelink = require('ewelink-api');
 })();
 ```
 
-> If you don't know your region, use [getRegion](/docs/available-methods/getregion) method
+> If you don't know your region, use [getRegion](/docs/available-methods/getregion.md) method


### PR DESCRIPTION
The link to getRegion doesn't include the file suffix .md

Martin,
Really I'm just starting to use git & github so I thought I'd start with a trivial fix.

--
Steve
