### PR TITLE
Add custom device power state to allow sending custom params

### DIFF
--- a/docs/available-methods/setdevicepowerstate.md
+++ b/docs/available-methods/setdevicepowerstate.md
@@ -15,7 +15,18 @@ Change specified device power state.
   console.log(status);
 ```
 
-Possible states: `on`, `off`, `toggle`.
+```js
+  // custom params, e.g. when setting brightness or color temperature on LED bulb
+  // (to find out the correct params, open a websocket connection, log the data,
+  // make a change in the app and observe the sent payload)
+  const status = await connection.setDevicePowerState('<your device id>', 'custom', <channel>, {
+    white: { br: 70, ct: 30 },
+    ltype: 'white'
+  });
+  console.log(status);
+```
+
+Possible states: `on`, `off`, `toggle`, `custom`.
 
 <sup>* _Remember to instantiate class before use_</sup>
 

--- a/docs/available-methods/setdevicepowerstate.md
+++ b/docs/available-methods/setdevicepowerstate.md
@@ -16,7 +16,7 @@ Change specified device power state.
 ```
 
 ```js
-  // custom params, e.g. when setting brightness or color temperature on LED bulb
+  // custom params, e.g. when setting LED bulb brightness or color temperature
   // (to find out the correct params, open a websocket connection, log the data,
   // make a change in the app and observe the sent payload)
   const status = await connection.setDevicePowerState('<your device id>', 'custom', <channel>, {

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module 'ewelink-api' {
     /**
      * Change specified device power state.
      */
-    setDevicePowerState(deviceId: string, state?: string, channel?: number): Promise<DeviceState>
+    setDevicePowerState(deviceId: string, state?: string, channel?: number, extraParams?: object): Promise<DeviceState>
     /**
      * Switch specified device current power state.
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module 'ewelink-api' {
     /**
      * Change specified device power state.
      */
-    setDevicePowerState(deviceId: string, state?: string, channel?: number, extraParams?: object): Promise<DeviceState>
+    setDevicePowerState(deviceId: string, state?: string, channel?: number, customParams?: object): Promise<DeviceState>
     /**
      * Switch specified device current power state.
      */

--- a/mixins/powerState/setDevicePowerStateMixin.js
+++ b/mixins/powerState/setDevicePowerStateMixin.js
@@ -16,7 +16,7 @@ const setDevicePowerState = {
    *
    * @returns {Promise<{state: *, status: string}|{msg: string, error: *}>}
    */
-  async setDevicePowerState(deviceId, state, channel = 1) {
+  async setDevicePowerState(deviceId, state, channel = 1, extraParams = {}) {
     const device = await this.getDevice(deviceId);
     const deviceApiKey = _get(device, 'apikey', false);
     const error = _get(device, 'error', false);
@@ -55,6 +55,12 @@ const setDevicePowerState = {
     } else {
       params.switch = stateToSwitch;
     }
+
+    if (state === 'custom') {
+      delete params.switch;
+    }
+
+    Object.assign(params, extraParams);
 
     if (this.devicesCache) {
       return ChangeStateZeroconf.set({

--- a/mixins/powerState/setDevicePowerStateMixin.js
+++ b/mixins/powerState/setDevicePowerStateMixin.js
@@ -16,7 +16,7 @@ const setDevicePowerState = {
    *
    * @returns {Promise<{state: *, status: string}|{msg: string, error: *}>}
    */
-  async setDevicePowerState(deviceId, state, channel = 1, extraParams = {}) {
+  async setDevicePowerState(deviceId, state, channel = 1, customParams = {}) {
     const device = await this.getDevice(deviceId);
     const deviceApiKey = _get(device, 'apikey', false);
     const error = _get(device, 'error', false);
@@ -58,9 +58,8 @@ const setDevicePowerState = {
 
     if (state === 'custom') {
       delete params.switch;
+      Object.assign(params, customParams);
     }
-
-    Object.assign(params, extraParams);
 
     if (this.devicesCache) {
       return ChangeStateZeroconf.set({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ewelink-api",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ewelink-api",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "eWeLink API for Node.js",
   "author": "Martín M.",
   "license": "MIT",


### PR DESCRIPTION
:wave: This small change allows to send custom params for advanced use cases - in my case changing the color temperature and brightness of an LED bulb. While injecting that into `setDevicePowerState` is not perfect, because we are not really changing the power state, it felt wrong also to create a different mixin just for this. Let me know if a test needs to be added.