### PR TITLE
Fix only send the switch being changed in setDevicePowerState

### DIFF
--- a/src/mixins/setDevicePowerState.js
+++ b/src/mixins/setDevicePowerState.js
@@ -45,8 +45,8 @@ module.exports = {
     }
 
     if (switches) {
-      params.switches = switches;
-      params.switches[channel - 1].switch = stateToSwitch;
+      params.switches = [ switches[channel-1] ]
+      params.switches[0].switch = stateToSwitch;
     } else {
       params.switch = stateToSwitch;
     }


### PR DESCRIPTION
This is usefull when using LAN mode since the cached states could be wrong