### PR TITLE
fix: make arpping an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     ]
   },
   "dependencies": {
-    "arpping": "github:skydiver/arpping",
     "crypto-js": "^4.0.0",
     "delay": "^4.4.0",
     "node-fetch": "^2.6.1",
@@ -63,5 +62,8 @@
     "jest": "^26.5.3",
     "nock": "^12.0.3",
     "prettier": "^1.19.1"
+  },
+  "optionalDependencies": {
+    "arpping": "github:skydiver/arpping"
   }
 }

--- a/src/classes/Zeroconf.js
+++ b/src/classes/Zeroconf.js
@@ -1,5 +1,10 @@
 const fs = require('fs');
-const arpping = require('arpping')({});
+let arpping
+
+try {
+  arpping = require('arpping')({});
+} catch ( err ) {
+}
 
 class Zeroconf {
   /**
@@ -9,13 +14,17 @@ class Zeroconf {
    */
   static getArpTable(ip = null) {
     return new Promise((resolve, reject) => {
-      arpping.discover(ip, (err, hosts) => {
-        if (err) {
-          return reject(err);
-        }
-        const arpTable = Zeroconf.fixMacAddresses(hosts);
-        return resolve(arpTable);
-      });
+      if ( !arpping ) {
+        reject(new Error('arpping is not installed'))
+      } else {
+        arpping.discover(ip, (err, hosts) => {
+          if (err) {
+            return reject(err);
+          }
+          const arpTable = Zeroconf.fixMacAddresses(hosts);
+          return resolve(arpTable);
+        });
+      }
     });
   }
 


### PR DESCRIPTION
Install fails on platforms where there is no binary available, but is not always needed