### PR TITLE
Version 4.0.0:  Add getHomepage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
   * [openWebSocket](available-methods/openwebsocket.md)
   * [getDevice](available-methods/getdevice.md)
   * [getDevices](available-methods/getdevices.md)
+  * [getHomepage](available-methods/gethomepage.md)
   * [getDevicePowerState](available-methods/getdevicepowerstate.md)
   * [setDevicePowerState](available-methods/setdevicepowerstate.md)
   * [getWSDevicePowerState](available-methods/getwsdevicepowerstate.md)

--- a/docs/available-methods/gethomepage.md
+++ b/docs/available-methods/gethomepage.md
@@ -1,0 +1,13 @@
+# getDevices
+
+Get "homepage", which includes information about all scenes and registered devices
+
+
+### Usage
+```
+  /* get homepage */
+  const data = await connection.getHomepage();
+  console.log(data);
+```
+
+<sup>* _Remember to instantiate class before use_</sup>

--- a/src/mixins/getHomepage.js
+++ b/src/mixins/getHomepage.js
@@ -1,0 +1,35 @@
+const { _get } = require('../helpers/utilities');
+const errors = require('../data/errors');
+
+module.exports = {
+  /**
+   * Get "homepage", which includes information about all scenes and registered devices 
+   *
+   * @returns {Promise<{msg: string, error: number}|*>}
+   */
+  async getHomepage() {
+
+    const response = await this.makeRequest({
+      method: "post",
+      uri: `/v2/homepage`,
+      body: {
+        getFamily: {},
+        getThing: {},
+      },
+    });
+
+    const error = _get(response, 'error', false);
+    const familyInfo = _get(response, 'familyInfo', false);
+    const thingInfo = _get(response, 'thingInfo', false);
+
+    if (error) {
+      throw new Error(`[${error}] ${errors[error]}`);
+    }
+
+    if (!familyInfo || !thingInfo) {
+      throw new Error(`${errors.noDevices}`);
+    }
+
+    return { familyInfo, thingInfo };
+  },
+};

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -10,6 +10,7 @@ const { getDevicePowerState } = require('./getDevicePowerState');
 const { getDevicePowerUsage } = require('./getDevicePowerUsage');
 const { getDevicePowerUsageRaw } = require('./getDevicePowerUsageRaw');
 const { getDevices } = require('./getDevices');
+const { getHomepage } = require('./getHomepage');
 const { getFirmwareVersion } = require('./getFirmwareVersion');
 const { getRegion } = require('./getRegion');
 const { makeRequest } = require('./makeRequest');
@@ -31,6 +32,7 @@ const mixins = {
   getDevicePowerUsage,
   getDevicePowerUsageRaw,
   getDevices,
+  getHomepage,
   getFirmwareVersion,
   getRegion,
   makeRequest,


### PR DESCRIPTION
This adds a call to `/v2/getHomepage`, which gives the full rundown of all the account's scenes and devices.

Side note is that this is a `v2` endpoint, so I'm purposefully merging it into the `release/4.0.0` branch.  It would be great to get that branch landed in master as to avoid confusion.